### PR TITLE
fix(player): Resolve issues with player open/close buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,11 +276,14 @@
             prevBtn.addEventListener('click', playPrevTrack);
             nextBtn.addEventListener('click', playNextTrack);
 
-            stopBtnMinimized.addEventListener('click', (e) => {
-                e.stopPropagation(); 
-                stopStation();
+            stopBtnMinimized.addEventListener('click', stopStation);
+            minimizedPlayer.addEventListener('click', (e) => {
+                // If the click was on the stop button, let its own handler deal with it.
+                if (e.target.closest('#stop-btn-minimized')) {
+                    return;
+                }
+                showFullscreenPlayer();
             });
-            minimizedPlayer.addEventListener('click', showFullscreenPlayer);
 
             audioPlayer.addEventListener('error', (e) => {
                 console.error("Audio playback error:", e);
@@ -565,18 +568,28 @@
             mainContent.classList.add('hidden');
         }
 
-        function minimizePlayerView(e) {
-            if (e) e.stopPropagation(); // Prevent any parent handlers from being notified of the event.
+        function minimizePlayerView() {
             fullscreenPlayer.classList.add('hidden');
-            minimizedPlayer.classList.remove('hidden');
             mainContent.classList.remove('hidden');
+            // Use a small timeout to prevent the click event from immediately re-triggering the player
+            setTimeout(() => {
+                minimizedPlayer.classList.remove('hidden');
+            }, 50);
         }
 
 
         // --- Favorite Functions (localStorage) ---
         function getFavorites() {
             const favoritesString = localStorage.getItem('media-player-favorites');
-            return favoritesString ? JSON.parse(favoritesString) : [];
+            if (!favoritesString) return [];
+            try {
+                return JSON.parse(favoritesString);
+            } catch (e) {
+                console.error("Error parsing favorites from localStorage", e);
+                // If parsing fails, the data is corrupt, so we clear it.
+                localStorage.removeItem('media-player-favorites');
+                return [];
+            }
         }
 
         function saveFavorites() {


### PR DESCRIPTION
This commit fixes the functionality of the fullscreen player's minimize button and the minimized player's open action.

- A timeout is added to `minimizePlayerView` to prevent a race condition where the click event could immediately re-trigger the player to open.
- The click handler for the minimized player is made more robust to ignore clicks on the stop button, preventing conflicts.

fix(favorites): Improve stability of localStorage parsing

This commit adds a `try...catch` block to the `getFavorites` function. This prevents the application from crashing if the favorite data stored in `localStorage` is corrupted. If parsing fails, the corrupted data is removed, and the app continues to run with an empty favorites list.